### PR TITLE
specified BIOPERL_VERSION

### DIFF
--- a/RSAT_config_default.bashrc
+++ b/RSAT_config_default.bashrc
@@ -51,6 +51,7 @@ export CVS_RSH=ssh
 ## Default path for the Ensembl Perl modules and sofwtare tools
 export ENSEMBL_RELEASE=105
 export ENSEMBLGENOMES_RELEASE=52
+export BIOPERL_VERSION=1-2-3
 export PATH=${RSAT}/ext_lib/ensemblgenomes-${ENSEMBLGENOMES_RELEASE}-${ENSEMBL_RELEASE}/ensembl-git-tools/bin:${PATH}
 export PERL5LIB=${RSAT}/ext_lib/bioperl-release-${BIOPERL_VERSION}/bioperl-live::${PERL5LIB}
 export PERL5LIB=${RSAT}/ext_lib/ensemblgenomes-${ENSEMBLGENOMES_RELEASE}-${ENSEMBL_RELEASE}/ensembl/modules::${PERL5LIB}


### PR DESCRIPTION
BIOPERL_VERSION was apparently not defined in the default RSAT_config_default.bash so that Bioperl was not found in the PERL5LIB path. 