### PR TITLE
link to external motif collection (ie footprintDB) from peak-motifs HTML tabular output

### DIFF
--- a/perl-scripts/peak-motifs
+++ b/perl-scripts/peak-motifs
@@ -4267,6 +4267,25 @@ sub SmallSummary {
 }
 
 
+################################################################
+## Produces a string with a URL to display a motif in an external database.
+## For enabled dbs (ie footprintDB) makes the "Discovered motifs (with motif comparison)"
+## HTML table interactive.
+## If database not enabled returns original motif name.
+## Decided to define URLs here as they might not necessarily match the entrypoint URLs in
+## file motif_databases/db_matrix_files.tab
+sub MotifExternalURL {
+
+  my ($db_name, $motif_name ) = @_;
+  my $URL = $motif_name;
+
+  if($db_name =~ m/^footprintDB/ && $motif_name !~ m/\s+/) {
+    $URL = 'https://footprintdb.eead.csic.es/index.php?motif=' . $motif_name;
+  }
+
+  return $URL
+}
+
 
 ################################################################
 ## Delete purged sequence files after analysis has been completed.

--- a/perl-scripts/peak-motifs
+++ b/perl-scripts/peak-motifs
@@ -3012,6 +3012,7 @@ sub SynthesisOneMotifComparison {
     my @values = ();
     foreach my $field (@match_fields) {
       my $value = "NA";
+
       if (defined($col_index{$field})) {
 	my $column = $col_index{$field};
 	$value = $fields[$column];
@@ -3019,7 +3020,19 @@ sub SynthesisOneMotifComparison {
 	  $value = &RSAT::SeqUtil::ColorConsensus($value, bold=>1, iupac=>$main::param{iupac_coloring});
 	}
       }
-      $db_match_table .= "\n<td>".$value."</td>\n\n";
+      
+      # add URL to motif in external database, or else simply concat motif name (field name2)
+      if($field eq 'name2') {
+        my $URL = MotifExternalURL($db_name, $value);
+        if($URL =~ /^http/) {
+          $db_match_table .= "\n<td><a href=\"$URL\" target=\"_blank\">".$value."</a></td>\n\n";
+        } else {
+          $db_match_table .= "\n<td>".$value."</td>\n\n";
+        }
+      } else {
+        $db_match_table .= "\n<td>".$value."</td>\n\n";
+      }
+
       #&RSAT::message::Debug("DB matches", $db_name, $match_nb, $field, "col=".$column, "value=".$value, $file) if ($main::verbose >= 10);
     }
     $db_match_table .= "</tr>\n\n";


### PR DESCRIPTION
Hi @morganeTC @jvanheld @najlaksouri ,
just added a simple function, sub MotifExternalURL, which adds hyperlinks to external motif collections within the tabular HTML output produced by peak-motifs.  It only has an effect if the user requests comparing the motifs found by peak-motifs to motif databases. For the moment it works only for footprintDB, but can be extended to other motif databases in the future.

What this does is it contructs a URL using the motif name (field 'name2') if it comes from an enabled database. The URL opens in a new tab. If this fails it simply returns the original motif name and the first column in the table will be text-only (default). 

In the case of footprintDB results this greatly facilitates browsing the annotated transcription factors known to bind to a particular motif and to the relevant papers, see the links in the column 'name' in the screenshot below:

![imagen](https://github.com/rsa-tools/rsat-code/assets/15164836/befd7be1-998d-41d8-bbbc-62566f44a8ef)

