### PR TITLE
Added instrucctions on how to install organisms when there are no organisms installed and supported-organisms script is called

### DIFF
--- a/perl-scripts/supported-organisms
+++ b/perl-scripts/supported-organisms
@@ -79,14 +79,14 @@ package main;
     ################################################################
     ## Get the list supported organisms from a remote RSAT server
     if ($from_server) {
-	&RSAT::message::Warning("Option -server is obsolete, the query will be passed to the separate program supported-organisms-server");
+		&RSAT::message::Warning("Option -server is obsolete, the query will be passed to the separate program supported-organisms-server");
 
-	## Pass the query to supported-organisms-server
-	my $cmd =  &RSAT::server::GetProgramPath("supported-organisms-server");
-	my $parameters = &PrintArguments();
-	&doit($cmd." ".$parameters);
+		## Pass the query to supported-organisms-server
+		my $cmd =  &RSAT::server::GetProgramPath("supported-organisms-server");
+		my $parameters = &PrintArguments();
+		&doit($cmd." ".$parameters);
 
-	exit(0);
+		exit(0);
 
     } else {
       if (($out_format eq "tree")||($out_format eq "html_tree")||$out_format eq "newick") {
@@ -116,7 +116,13 @@ package main;
 	for my $source (@sources) {
         $result .= &RSAT::OrganismManager::supported_organism_table($verbose, 0, $source, $taxon, $group, $depth, $with_variant, $with_blast, @return_fields); ## Export the table with header and absolute paths;
 	}
-	print $out $result;
+	if ($result){
+		print $out $result;
+		}
+	else {
+		$help = " No organisms found.\n To install organisms use:\n\tdownload-organism -v 2 -org <organism> -server <server> \n For exemple, To download an organism from an already working rsat environment (E.g  https://rsat.eead.csic.es/plants/ )  visit the supported-organisms.cgi page (https://rsat.eead.csic.es/plants/supported-organisms.cgi) \n Then use the previously mentioned command with server info and desired organisms \n\tdownload-organism -v 2 -org Prunus_persica.Prunus_persica_NCBIv2.60 -server https://rsat.eead.csic.es/plants \n For how to download them using containers, visit:\n\tDocker: https://rsa-tools.github.io/installing-RSAT/RSAT-Docker/RSAT-Docker-tuto.html#4_Installation_instructions\n\tApptainer: https://rsa-tools.github.io/installing-RSAT/RSAT-Docker/RSAT-Apptainer-tuto.html#4_Installation_instructions\n To see how to execute scripts inside the containers \n";
+		print $help;
+		}
       }
     }
 


### PR DESCRIPTION
When supported-organisms script is called, there is no output. Although this is enough to see that there is no organisms installed, this pull request shows a friendlier message when there is no supported organisms, while giving instructions on how to download and install genomes from RSAT servers:

Current behavior:

    rsat_user@c9c65f8253fa:~$ supported-organisms
    rsat_user@c9c65f8253fa:~$ 

(There's no output)

New behavior:

    rsat_user@c9c65f8253fa:~$ supported-organisms
             No organisms found.
             To install organisms use:
                    download-organism -v 2 -org <organism> -server <server> 
             For exemple, To download an organism from an already working rsat environment (E.g  https://rsat.eead.csic.es/plants/ )  visit the supported-organisms.cgi page (https://rsat.eead.csic.es/plants/supported-organisms.cgi) 
             Then use the previously mentioned command with server info and desired organisms 
                    download-organism -v 2 -org Prunus_persica.Prunus_persica_NCBIv2.60 -server https://rsat.eead.csic.es/plants 
             For how to download them using containers, visit:
                    Docker: https://rsa-tools.github.io/installing-RSAT/RSAT-Docker/RSAT-Docker-tuto.html#4_Installation_instructions
                    Apptainer: https://rsa-tools.github.io/installing-RSAT/RSAT-Docker/RSAT-Apptainer-tuto.html#4_Installation_instructions
             To see how to execute scripts inside the containers
    rsat_user@c9c65f8253fa:~$ 

(Explicitely says that there are no organisms and shows how to install them, and redirect them to the documentation for the use inside the container)

In case there are installed organisms, behavior has not changed:

    rsat_user@c9c65f8253fa:~$  ./supported-organisms
        Arabidopsis_thaliana.TAIR10.60
        Drosophila_melanogaster
        Oryza_sativa.IRGSP-1.0.60
        Prunus_persica.Prunus_persica_NCBIv2.60
        Saccharomyces_cerevisiae
    rsat_user@c9c65f8253fa:~$ 