### PR TITLE
Supported motifs script now can show the absolute path of the database motifs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -168,7 +168,7 @@ ENV RSATUSER="rsat_user"
 ENV RSATPASS="rsat_2020"
 ENV RSATUSERHOME="/home/${RSATUSER}"
 ENV TESTPATH="${RSATUSERHOME}/test_data"
-ENV EXTMOTIFPATH="${RSATUSERHOME}/ext_motifs"
+ENV MOTIFPATH="/packages/motif_databases"
 
 RUN useradd ${RSATUSER} \
 	&& echo "${RSATUSER}:${RSATPASS}" | chpasswd \

--- a/perl-scripts/lib/RSAT/OrganismManager.pm
+++ b/perl-scripts/lib/RSAT/OrganismManager.pm
@@ -460,9 +460,9 @@ sub get_supported_organisms_web {
       push @selected_organisms , &RSAT::OrganismManager::GetOrganismsForGroup($group_specificity);
       if (scalar(@selected_organisms) < 1) {
 	if (lc($ENV{group_specificity}) eq "none") {
-	  &RSAT::error::FatalError("No organism supported on this server");
+	  &RSAT::error::FatalError("No organisms supported on this server. Check <a href='https://rsa-tools.github.io/installing-RSAT/RSAT-Docker/RSAT-Docker-tuto.html#4_Installation_instructions'>Documentation</a> to download organisms from RSAT servers");
 	} else {
-	  &RSAT::error::FatalError("No organism supported on this server for group", $ENV{group_specificity});
+	  &RSAT::error::FatalError("No organisms supported on this server for group", $ENV{group_specificity});
 	}
       }
     }

--- a/perl-scripts/supported-motif-databases
+++ b/perl-scripts/supported-motif-databases
@@ -80,6 +80,8 @@ package main;
   our %infile = ();
   our %outfile = ();
 
+  our abspath = 0;
+
   our $verbose = 0;
   our $in = STDIN;
   our $out = STDOUT;
@@ -112,10 +114,14 @@ package main;
 
   ################################################################
   ## Insert here output printing
+
   print $out "#", join("\t", @selected_out_fields), "\n";
   foreach my $db (sort keys %matrix_db) {
     my @out_fields = ();
     foreach my $field (@selected_out_fields) {
+      if ($field eq "file" && $abspath){
+          $matrix_db{$db}->{$field} = $ENV{MOTIFPATH}.$matrix_db{$db}->{$field});
+      }
       push @out_fields, $matrix_db{$db}->{$field};
     }
     print $out join("\t", @out_fields), "\n";
@@ -210,6 +216,10 @@ Display full help message
 Same as -h
 
 =cut
+    } elseif ($arg eq "-f") {
+      #set abspath for the paths printed
+      $abspath = 1; 
+    
     } elsif ($arg eq "-help") {
       &PrintOptions();
 


### PR DESCRIPTION
Supported-motif-database script now is able to show the absolute path when environment variable MOTIFPATH is established by using -f argument

Not using -f will have the same behavior as it does now, by printing the relative path specified in the /packages/motif-databases/ 
/packages/motif_databases/db_matrix_files.tab

Also, the message thrown in the web interface when there is no installed genomes has been updated to add a link to documentation on how to install genomes, similarly to how supported-organisms works now