### PR TITLE
Fix to the supported-motif-databases to avoid syntax errors plus start of test suit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -169,6 +169,7 @@ ENV RSATPASS="rsat_2020"
 ENV RSATUSERHOME="/home/${RSATUSER}"
 ENV TESTPATH="${RSATUSERHOME}/test_data"
 ENV MOTIFPATH="/packages/motif_databases"
+ENV EXTMOTIFPATH="/packages/motif_databases/ext_motifs"
 
 RUN useradd ${RSATUSER} \
 	&& echo "${RSATUSER}:${RSATPASS}" | chpasswd \

--- a/perl-scripts/supported-motif-databases
+++ b/perl-scripts/supported-motif-databases
@@ -80,7 +80,7 @@ package main;
   our %infile = ();
   our %outfile = ();
 
-  our abspath = 0;
+  our $abspath = 0;
 
   our $verbose = 0;
   our $in = STDIN;
@@ -120,7 +120,7 @@ package main;
     my @out_fields = ();
     foreach my $field (@selected_out_fields) {
       if ($field eq "file" && $abspath){
-          $matrix_db{$db}->{$field} = $ENV{MOTIFPATH}.$matrix_db{$db}->{$field});
+          $matrix_db{$db}->{$field} = $ENV{MOTIFPATH}.$matrix_db{$db}->{$field};
       }
       push @out_fields, $matrix_db{$db}->{$field};
     }
@@ -216,7 +216,7 @@ Display full help message
 Same as -h
 
 =cut
-    } elseif ($arg eq "-f") {
+    } elsif ($arg eq "-f") {
       #set abspath for the paths printed
       $abspath = 1; 
     

--- a/rsat-testing.sh
+++ b/rsat-testing.sh
@@ -1,0 +1,27 @@
+#! /bin/bash -x
+
+function test_command(){
+    $@
+    result=$?
+    echo $result
+    if [ $result -ne 0 ];
+    then
+        echo "Command $@ failed with exit code $result"
+        exit 1
+    fi
+}
+
+
+
+test_command rsat -h
+test_command rsat oligo-analysis -h ## Test a subcommand running a Perl script
+test_command rsat random-seq -l 100 -n 2 ## Test a perl script
+test_command rsat random-seq -l 100 -n 2 | rsat purge-sequence 
+test_command rsat random-motif -l 10 ## Test a subcommand running a python script
+test_command rsat feature-map -h ## check the GD dependency for feature-map
+test_command rsat info-gibbs -h
+test_command rsat count-words -h
+test_command rsat matrix-scan-quick -h
+test_command rsat matrix-clustering -h ## Test if the specific Perl dependencies have been successfully included for this tool
+test_command make -f $(pwd)/makefiles/subcommand_tests.mk randseq ## Quick test for one Perl script
+test_command make -f $(pwd)/makefiles/subcommand_tests.mk xygraph ## test GD dependency


### PR DESCRIPTION
After the meeting we had yesterday I noticed a small bug, as the commit in the pull request weren correct. This fixes it.

It also add a bash script that serves as starting point for an automated test suit, from the tests that were present in bioconda's recipe