### PR TITLE
FIX: div in htmllink.cgi has now standard height

### DIFF
--- a/public_html/htmllink.cgi
+++ b/public_html/htmllink.cgi
@@ -75,7 +75,7 @@ print $query->start_html (-title=>"$title",
     }
     
     
-    print "<div class='container' id='page-content-wrapper' style='max-width:900px'>";
+    print "<div class='container' id='page-content-wrapper' style='max-width:1920px;height:1080px;'>";
 
 
 	print "<iframe src=$file frameborder='0' width='100%' height='100%' ></iframe>";


### PR DESCRIPTION
A div in htmllink had inadequate heigh difficulting seeing the files listed

![image](https://github.com/user-attachments/assets/91d82b88-a217-480b-a937-685e3f207f0b)

It seems to be a height inherited from some element not explicitely shown and not explicitely shown in CSS. To avoid changing values that might affect elsewhere, height has been explicitely set for this div in htmmling.cgi

In particular, height has been set to 1080px and width to a maximum of 1920px, following FullHD standard resolution

![image](https://github.com/user-attachments/assets/1b2bd8da-6e4f-499a-b930-c846e7059138)

For inferior heights, there's a slider.

![image](https://github.com/user-attachments/assets/95d29a37-6669-46f8-93af-9f765aa78e9e)

