### PR TITLE
Add example usages for rsat_safe_* helpers in CGI forms and scripts

### DIFF
--- a/perl-scripts/lib/RSA2.cgi.lib
+++ b/perl-scripts/lib/RSA2.cgi.lib
@@ -1,5 +1,7 @@
 #!/usr/bin/env perl
 use CGI;
+use Cwd qw(abs_path);
+use File::Spec;
 
 use LWP::Simple;
 use JSON;
@@ -197,8 +199,9 @@ sub ListParameters {
   print "<ul><table>\n";
   foreach my $key (@param) {
     print "<tr>";
-    print "<td valign=top><b>$key</b></td>";
+    print "<td valign=top><b>", &rsat_safe_html($key), "</b></td>";
     my $value = $query->param($key);
+    $value = &rsat_safe_html($value);
     $value =~ s/\n/<br>/g;
     print "<td valign=top>$value</td>";
     print "</tr>\n";
@@ -216,8 +219,9 @@ sub ListDefaultParameters {
   print "<ul><table>\n";
   foreach my $key (sort keys %main::default) {
     print "<tr>";
-    print "<td valign=top><b>$key</b></td>";
+    print "<td valign=top><b>", &rsat_safe_html($key), "</b></td>";
     my $value = $default{$key};
+    $value = &rsat_safe_html($value);
     $value =~ s/\n/<br>/g;
     print "<td valign=top>$value</td>";
     print "</tr>\n";
@@ -231,11 +235,71 @@ sub ListDefaultParameters {
 sub Print_CGI_Input {
     print "<pre>";
     foreach $key (sort keys %input) {
-	print "$key\t$input{$key}\n";
+	print &rsat_safe_html($key), "\t", &rsat_safe_html($input{$key}), "\n";
     }
     print "</pre>";
 
-    print "Parameters: $parameters<P><P>\n";
+    print "Parameters: ", &rsat_safe_html($parameters), "<P><P>\n";
+}
+
+## Escape a value for safe insertion as plain HTML text content.
+## This is meant for text nodes, not for raw HTML, URLs, or full attribute validation.
+sub rsat_safe_html {
+  my ($value) = @_;
+  return '' unless defined $value;
+  return CGI::escapeHTML("$value");
+}
+
+## Encode a value as a JavaScript string literal.
+## The extra escaping keeps it safer when embedded in inline handlers inside HTML.
+sub rsat_safe_js_string {
+  my ($value) = @_;
+  $value = '' unless defined $value;
+  my $json = encode_json("$value");
+  $json =~ s/</\\u003C/g;
+  $json =~ s/>/\\u003E/g;
+  $json =~ s/&/\\u0026/g;
+  $json =~ s/'/\\u0027/g;
+  return $json;
+}
+
+## Accept only readable regular files from approved local server-side roots.
+## The path is trimmed, canonicalized, and rejected if it escapes the allowed directories.
+sub rsat_safe_local_file_param {
+  my ($path) = @_;
+  return undef unless defined $path;
+  $path =~ s/^\s+//;
+  $path =~ s/\s+$//;
+  return undef unless length $path;
+  return undef if $path =~ /[\0\r\n]/;
+
+  my $abs_path = abs_path($path);
+  return undef unless defined $abs_path;
+  return undef unless -f $abs_path;
+  return undef unless -r $abs_path;
+
+  my @allowed_roots = grep { defined && length($_) }
+    ($ENV{RSAT}, $ENV{TMPDIR}, '/tmp');
+
+  foreach my $root (@allowed_roots) {
+    my $abs_root = abs_path($root);
+    next unless defined $abs_root;
+    return $abs_path if $abs_path eq $abs_root;
+    return $abs_path if index($abs_path, $abs_root . '/') == 0;
+  }
+
+  return undef;
+}
+
+## Quote one shell argument for POSIX shells after minimal validation.
+## This protects a single argument, but building full shell command strings is still risky.
+sub rsat_shell_quote {
+  my ($value) = @_;
+  die "Undefined shell argument" unless defined $value;
+  $value = "$value";
+  die "Invalid NUL byte in shell argument" if $value =~ /\0/;
+  $value =~ s/'/'"'"'/g;
+  return "'" . $value . "'";
 }
 
 

--- a/public_html/XYgraph.cgi
+++ b/public_html/XYgraph.cgi
@@ -43,10 +43,10 @@ $parameters = " -v 1";
 
 ### general parameters ###
 if ($query->param('title')) {
-    $parameters .= " -title1 \"".$query->param('title')."\" ";
+    $parameters .= " -title1 ".&rsat_shell_quote($query->param('title'))." ";
 }
 if ($query->param('title2')) {
-    $parameters .= " -title2 \"".$query->param('title2')."\" ";
+    $parameters .= " -title2 ".&rsat_shell_quote($query->param('title2'))." ";
 }
 if (&IsNatural($query->param('pointsize'))) {
     $parameters .= " -pointsize ".$query->param('pointsize');
@@ -81,10 +81,10 @@ if ($query->param('xcol')) {
     $parameters .= " -xcol ".$query->param('xcol');
 }
 if ($query->param('xleg1')) {
-    $parameters .= " -xleg1 \"".$query->param('xleg1')."\"";
+    $parameters .= " -xleg1 ".&rsat_shell_quote($query->param('xleg1'));
 }
 if ($query->param('xleg2')) {
-    $parameters .= " -xleg2 \"".$query->param('xleg2')."\"";
+    $parameters .= " -xleg2 ".&rsat_shell_quote($query->param('xleg2'));
 }
 if (&IsReal($query->param('xmin'))) {
     $parameters .= " -xmin ".$query->param('xmin');
@@ -110,10 +110,10 @@ if ($query->param('ycol')) {
     $parameters .= " -ycol ".$query->param('ycol');
 }
 if ($query->param('yleg1')) {
-    $parameters .= " -yleg1 \"".$query->param('yleg1')."\"";
+    $parameters .= " -yleg1 ".&rsat_shell_quote($query->param('yleg1'));
 }
 if ($query->param('yleg2')) {
-    $parameters .= " -yleg2 \"".$query->param('yleg2')."\"";
+    $parameters .= " -yleg2 ".&rsat_shell_quote($query->param('yleg2'));
 }
 if (&IsReal($query->param('ymin'))) {
     $parameters .= " -ymin ".$query->param('ymin');
@@ -142,7 +142,8 @@ if ($ENV{R_supported} && !$query->param('htmap')){
 ## data file 
 if ($query->param('data_file') =~ /\S/) {
     ### file on the server
-    $data_file = $query->param('data_file');
+    $data_file = &rsat_safe_local_file_param($query->param('data_file'));
+    &FatalError("Invalid data file") unless $data_file;
 
 } elsif ($query->param('uploaded_file')) {
     ### upload file from the client
@@ -168,21 +169,24 @@ if ($query->param('data_file') =~ /\S/) {
 }
 push @result_files, "Input data (tab)", $data_file;
 
-$parameters .= " -i ".$data_file;
+$parameters .= " -i ".&rsat_shell_quote($data_file);
 
 ### graph file ###
 $image_format = $query->param('format') || $ENV{rsat_img_format} || "png";
+unless ($image_format =~ /^(png|jpg|jpeg|gif|svg|ps|pdf|eps)$/i) {
+    $image_format = "png";
+}
 $graph_file = $tmp_file_path.".".$image_format;
 push @result_files, "XY graph ($image_format)", $graph_file;
 $parameters .= " -format ".$image_format;
-$parameters .= " -o ".$graph_file;
+$parameters .= " -o ".&rsat_shell_quote($graph_file);
 
 if ($query->param('htmap')) {
     $htmap = 1;
     $htmap_file = $tmp_file_path.".html";
     push @result_files, "HTML map", $htmap_file;
 #    $parameters .= " -htmap ";
-    $parameters .= " -htmap > ".$htmap_file;
+    $parameters .= " -htmap > ".&rsat_shell_quote($htmap_file);
 }
 
 $XYgraph_command .= " ".$parameters;
@@ -232,6 +236,5 @@ print &HtmlBot();
 &DelayedRemoval($data_file);
 
 exit(0);
-
 
 

--- a/public_html/XYgraph_form.cgi
+++ b/public_html/XYgraph_form.cgi
@@ -55,8 +55,9 @@ foreach $key (keys %default) {
 
 
 #### specific treatment for internal XYgraph file (piped from dna-patttern)
-if (-e $query->param('XYgraph_file')) {
-    $file = $query->param('XYgraph_file');
+my $xygraph_file = &rsat_safe_local_file_param($query->param('XYgraph_file'));
+if ($xygraph_file) {
+    $file = $xygraph_file;
     $default{data} = `cat $file`;
 } else {
     $default{data} = $query->param('data');
@@ -325,7 +326,7 @@ function setDemo(demo_data){
 </script>';
 
 print "<TD><B>";
-print '<button type="button" onclick="setDemo('. "'$demo_data'" .')">DEMO</button>';
+print '<button type="button" onclick="setDemo(' . &rsat_safe_js_string($demo_data) . ')">DEMO</button>';
 print "</B></TD>\n";
 #print "<TD><B><A HREF='help.XYgraph.html'>MANUAL</A></B></TD>\n";
 
@@ -386,4 +387,3 @@ EndCredits
 ## close the form
 print $query->end_html;
 exit();
-

--- a/public_html/classfreq.cgi
+++ b/public_html/classfreq.cgi
@@ -48,7 +48,9 @@ $data_file = $tmp_file_path."_input.tab";
 
 if ($query->param('transferred_file') =~ /\S/) {
   ## Use local data file (transferred from previous query)
-  $data_file = $query->param('transferred_file');
+  my $transferred_file = &rsat_safe_local_file_param($query->param('transferred_file'));
+  &cgiError("Invalid transferred file") unless $transferred_file;
+  $data_file = $transferred_file;
 } elsif ($query->param('uploaded_file')) {
   ## Upload file from the client computer
   open DATA, ">$data_file";
@@ -71,7 +73,7 @@ if ($query->param('transferred_file') =~ /\S/) {
     &cgiError("The data box cannot be empty\n");
 }
 
-$parameters .= " -i ".$data_file;
+$parameters .= " -i ".&rsat_shell_quote($data_file);
 push @result_files, ("data",$data_file);
 
 ## Parameters
@@ -142,34 +144,23 @@ exit(0);
 sub PipingForm {
     my $data = `cat $result_file`;
     ### prepare data for piping
-    print <<End_of_form;
-<hr>
-<table class='nextstep'>
-
-<tr><td colspan=2>
-<h3>Next step</h3>
-</td></tr>
-
-<tr>
-
-<td><form method="post" action="XYgraph_form.cgi">
-<input type="hidden" name="data" VALUE="$data">
-<input type="hidden" name="xcol" VALUE="3">
-<input type="hidden" name="ycol" VALUE="4,5,6">
-<input type="hidden" name="title" VALUE="Frequency distribution">
-<input type="hidden" name="xsize" VALUE="600">
-<input type="hidden" name="xleg1" VALUE="Values">
-<input type="hidden" name="ysize" VALUE="400">
-<input type="hidden" name="yleg1" VALUE="Frequencies">
-<input type="hidden" name="lines" VALUE="on">
-<input type="submit" value="XYgraph">
-</form></td>
-
-</tr>
-
-
-</TABLE>
-End_of_form
+    print "<hr>\n";
+    print "<table class='nextstep'>\n";
+    print "<tr><td colspan=2><h3>Next step</h3></td></tr>\n";
+    print "<tr>\n";
+    print "<td>", $query->start_form(-method => 'post', -action => 'XYgraph_form.cgi'), "\n";
+    print $query->hidden(-name => 'data', -default => $data);
+    print $query->hidden(-name => 'xcol', -default => '3');
+    print $query->hidden(-name => 'ycol', -default => '4,5,6');
+    print $query->hidden(-name => 'title', -default => 'Frequency distribution');
+    print $query->hidden(-name => 'xsize', -default => '600');
+    print $query->hidden(-name => 'xleg1', -default => 'Values');
+    print $query->hidden(-name => 'ysize', -default => '400');
+    print $query->hidden(-name => 'yleg1', -default => 'Frequencies');
+    print $query->hidden(-name => 'lines', -default => 'on');
+    print $query->submit(-value => 'XYgraph');
+    print $query->end_form, "</td>\n";
+    print "</tr>\n";
+    print "</table>\n";
 
 }
-

--- a/public_html/classfreq_form.cgi
+++ b/public_html/classfreq_form.cgi
@@ -56,10 +56,10 @@ if ($query->param('transferred_file')) {
   my $file_url = $transferred_file;
   $file_url =~ s|$ENV{RSAT}/public_html|$ENV{rsat_www}|;
   $file =~ s|$ENV{rsat_www}|$ENV{RSAT}/public_html|;
-  print "<ul><a href=$file_url>";
+  print "<ul><a href='", &rsat_safe_html($file_url), "'>";
   print " transferred from previous query<BR>\n";
   print "</a></ul>";
-  print "<input type='hidden' NAME='transferred_file' VALUE='$transferred_file'>\n";
+  print $query->hidden(-name=>'transferred_file', -default=>$transferred_file), "\n";
 
 } else {
   $default{data} = $query->param('data');
@@ -197,4 +197,3 @@ print "</FONT>\n";
 print $query->end_html;
 
 exit(0);
-


### PR DESCRIPTION
This PR adds concrete examples showing how the RSAT safety helpers are used in existing CGI forms and processing scripts.

Included examples:
- rsat_safe_html for escaping plain HTML text output
- rsat_safe_js_string for embedding values in inline JavaScript handlers
- rsat_safe_local_file_param for validating local server-side file parameters
- rsat_shell_quote for quoting individual shell arguments

Example files referenced in this PR:
- classfreq_form.cgi / classfreq.cgi
- XYgraph_form.cgi / XYgraph.cgi

The goal is to make the intended use of each helper easier to understand during review and future maintenance.
