### PR TITLE
fix(security): [C3/C2] RSA2.cgi.lib — CheckWebInput, job_id, shell quote

### DIFF
--- a/perl-scripts/lib/RSA2.cgi.lib
+++ b/perl-scripts/lib/RSA2.cgi.lib
@@ -291,6 +291,28 @@ sub rsat_safe_local_file_param {
   return undef;
 }
 
+## Resolve a client-provided job identifier to a readable file under public temp.
+## This emergency guard rejects absolute/relative paths and only accepts simple IDs.
+sub rsat_resolve_job_id_file {
+  my ($job_id) = @_;
+  return undef unless defined $job_id;
+  $job_id =~ s/^\s+//;
+  $job_id =~ s/\s+$//;
+  return undef unless $job_id =~ /^[A-Za-z0-9._-]{1,200}$/;
+
+  my $tmp_root = &RSAT::util::get_pub_temp();
+  return undef unless defined $tmp_root && length $tmp_root;
+  my $root_abs = abs_path($tmp_root);
+  return undef unless defined $root_abs;
+
+  my $candidate = File::Spec->catfile($root_abs, $job_id);
+  my $candidate_abs = abs_path($candidate);
+  return undef unless defined $candidate_abs;
+  return undef unless -f $candidate_abs && -r $candidate_abs;
+  return undef unless index($candidate_abs, $root_abs . '/') == 0;
+  return $candidate_abs;
+}
+
 ## Quote one shell argument for POSIX shells after minimal validation.
 ## This protects a single argument, but building full shell command strings is still risky.
 sub rsat_shell_quote {
@@ -3292,6 +3314,48 @@ sub CheckWebInput {
       $tag =~ s/</&lt;/g;
       $tag =~ s/>/&gt;/g;
       &RSAT::error::FatalError("Invalid content for field \"$field\"", "<pre>$tag</pre>", "HTML tags are not allowed.");
+    }
+  }
+
+  ## Critical allow-list checks for parameters with known injection exposure.
+  my $origin = $cgi->param('origin');
+  if (defined $origin && $origin ne '' && $origin !~ /^(genomic|sequence)$/i) {
+    &RSAT::error::FatalError("Invalid value for parameter \"origin\".");
+  }
+
+  my $db_id = $cgi->param('db_id');
+  if (defined $db_id && $db_id ne '' && $db_id !~ /^[A-Za-z0-9_.-]{1,128}$/) {
+    &RSAT::error::FatalError("Invalid value for parameter \"db_id\".");
+  }
+
+  my $feattype = $cgi->param('feattype');
+  if (defined $feattype && $feattype ne '' && $feattype !~ /^[A-Za-z0-9_.-]{1,64}$/) {
+    &RSAT::error::FatalError("Invalid value for parameter \"feattype\".");
+  }
+
+  my $seq_type = $cgi->param('sequence_type');
+  if (defined $seq_type && $seq_type ne '' && $seq_type !~ /^[A-Za-z0-9_.-]{1,64}$/) {
+    &RSAT::error::FatalError("Invalid value for parameter \"sequence_type\".");
+  }
+
+  my $org_bg = $cgi->param('organism_bg');
+  if (defined $org_bg && $org_bg ne '') {
+    my $checked_org = &CheckOrganismAvail($org_bg);
+    if (!defined $checked_org || $checked_org eq '') {
+      &RSAT::error::FatalError("Invalid value for parameter \"organism_bg\".");
+    }
+  }
+
+  my $bg_format = $cgi->param('bg_format');
+  if (defined $bg_format && $bg_format ne '' && $bg_format !~ /^(oligo-analysis|tab|markov|transitions|counts|freq|frequency)$/i) {
+    &RSAT::error::FatalError("Invalid value for parameter \"bg_format\".");
+  }
+
+  foreach my $path_field (qw(feature_file XYgraph_file query_file)) {
+    my $value = $cgi->param($path_field);
+    next unless defined $value && $value ne '';
+    if ($value =~ m{[\\/]} || $value !~ /^[A-Za-z0-9._-]{1,200}$/) {
+      &RSAT::error::FatalError("Invalid value for parameter \"$path_field\".");
     }
   }
 }


### PR DESCRIPTION
# 🛡️ PR de Seguridad – RSAT

## 🚦 Estado del PR

- [x] Borrador / análisis inicial
- [x] Implementación en curso
- [x] Implementación terminada
- [ ] Probado en VM
- [ ] Pruebas funcionales completadas
- [ ] Pruebas de seguridad completadas
- [ ] Validado por Jacques
- [ ] Listo para merge


## 📌 Resumen

Endurecimiento central en RSA2.cgi.lib: resolución segura de job_id bajo get_pub_temp(), validación ampliada en CheckWebInput (origin, db_id, parámetros de fondo, rechazo de rutas en feature_file/XYgraph_file/query_file) y helper rsat_shell_quote para argumentos. Base para el resto de PRs de Fase 1.

---

## 🔍 Problema identificado

- Tipo de vulnerabilidad:
  - [x] Command Injection
  - [x] Path Traversal
  - [x] Arbitrary File Read
  - [x] Input Validation
  - [x] Otro: ___________

- Descripción:

La capa CGI compartida no impedía de forma uniforme rutas de cliente, valores peligrosos en origin/db_id ni prellenado seguro de formularios. Varios scripts dependían de la misma librería sin reglas comunes.

---

## ⚠️ Riesgo

- [x] Ejecución remota de comandos (RCE)
- [x] Lectura de archivos del sistema
- [ ] Exposición de datos
- [ ] Otro: ___________

---

## 🛠️ Cambios realizados

- Parámetro afectado: job_id, feature_file, XYgraph_file, query_file, origin, db_id, feattype, sequence_type, organism_bg, bg_format
- Estrategia aplicada: allow-list / regex + rsat_resolve_job_id_file; rechazo de paths con / o \
- Archivos modificados: 

```text
perl-scripts/lib/RSA2.cgi.lib
```


## 🔐 Nueva estrategia implementada

- rsat_resolve_job_id_file: solo IDs [A-Za-z0-9._-]{1,200}; fichero bajo abs_path(get_pub_temp()); sin shell.
- CheckWebInput: origin ∈ {genomic, sequence}; db_id con regex; validación de organism_bg vía CheckOrganismAvail; bg_format en lista cerrada; parámetros legacy de ruta rechazados si contienen separadores de path.
- rsat_shell_quote: cotización POSIX para uso puntual en CGIs (Fase 2 sustituirá ejecución vía shell).

Nota: este PR no elimina todos los open "|$cmd" del proyecto (Fase 2).





## 🧪 Pruebas de seguridad

### Caso: Path traversal

Input (en cualquier CGI que llame CheckWebInput):

```text
feature_file=../../../etc/passwd
```

Resultado esperado:

```text
error controlado (FatalError), sin lectura de /etc/passwd.
```

Resultado obtenido:

 ```text
(pendiente VM)
 ```


### Caso: origin inválido

Input:

 ```text
origin=genomic;id
 ```

Resultado esperado:

 ```text
Rechazo del parámetro
 ```

Resultado obtenido:

 ```text
(pendiente VM)
 ```

---

## ✅ Pruebas funcionales

- [ ] CGIs que llaman CheckWebInput arrancan sin error con parámetros válidos
- [ ] No regresión en cabecera/formularios que solo cargan la lib


Descripción:

 ```text
Smoke: cargar matrix-scan_form / feature-map con origin=genomic (pendiente VM).
 ```

---

## 📸 Evidencia
```text
(pendiente: captura de error RSAT o log tras petición maliciosa)
```
---

## ⚙️ Impacto

- [ ] No rompe compatibilidad
- [x] Cambios mínimos
- [x] Requiere documentación

Descripción:

```text
Descripción: Los PR 2–4 dependen de este merge. Flujos que enviaban rutas en feature_file deben migrar a job_id (PR 2).
```

---

## 📚 Documentación relacionada

Issue:
- https://github.com/rsa-tools/securing-policy/issues/4
- https://github.com/rsa-tools/securing-policy/issues/3
- https://github.com/rsa-tools/securing-policy/issues/2
- https://github.com/rsa-tools/securing-policy/issues/7
- https://github.com/rsa-tools/securing-policy/issues/8

---

## 👥 Revisión

- Implementado por: Carlos
- Revisado por: Bruno
- Validación final: Jacques

---

## 🚀 Checklist final

- [ ] Vulnerabilidad corregida
- [x] Inputs validados
- [ ] Sin uso de shell
- [ ] Pruebas de seguridad ejecutadas
- [ ] Pruebas funcionales ejecutadas
- [ ] Probado en VM
- [ ] Documentación actualizada
- [ ] Listo para validación

---

## 🧠 Notas adicionales

```text
Mergear este PR antes de PR2–PR4. 
```
