### PR TITLE
fix(security): [C1/H3/H4] forms prefill via job_id

### DIFF
--- a/public_html/XYgraph_form.cgi
+++ b/public_html/XYgraph_form.cgi
@@ -54,11 +54,14 @@ foreach $key (keys %default) {
 } 
 
 
-#### specific treatment for internal XYgraph file (piped from dna-patttern)
-my $xygraph_file = &rsat_safe_local_file_param($query->param('XYgraph_file'));
+#### specific treatment for internal XYgraph file: accept only job_id
+my $xygraph_file = &rsat_resolve_job_id_file($query->param('job_id'));
 if ($xygraph_file) {
-    $file = $xygraph_file;
-    $default{data} = `cat $file`;
+    if (open my $fh, "<", $xygraph_file) {
+        local $/ = undef;
+        $default{data} = <$fh>;
+        close $fh;
+    }
 } else {
     $default{data} = $query->param('data');
 }

--- a/public_html/feature-map_form.cgi
+++ b/public_html/feature-map_form.cgi
@@ -32,10 +32,14 @@ foreach $key (keys %default) {
     }
 }
 
-#### specific treatment for internal feature file (piped from dna-patttern)
-if (-e $query->param('feature_file')) {
-    $file = $query->param('feature_file');
-    $default{data} = `cat $file`;
+#### specific treatment for internal feature file: accept only job_id
+my $prefill_file = &rsat_resolve_job_id_file($query->param('job_id'));
+if ($prefill_file) {
+    if (open my $fh, "<", $prefill_file) {
+        local $/ = undef;
+        $default{data} = <$fh>;
+        close $fh;
+    }
 } else {
     $default{data} = $query->param('data');
 }

--- a/public_html/feature-map_form2.cgi
+++ b/public_html/feature-map_form2.cgi
@@ -36,9 +36,13 @@ foreach $key (keys %default) {
     }
 }
 
-if (-e $query->param('feature_file')) {
-    $file = $query->param('feature_file');
-    $default{data} = `cat $file`;
+my $prefill_file = &rsat_resolve_job_id_file($query->param('job_id'));
+if ($prefill_file) {
+    if (open my $fh, "<", $prefill_file) {
+        local $/ = undef;
+        $default{data} = <$fh>;
+        close $fh;
+    }
 } else {
     $default{data} = $query->param('data');
 }

--- a/public_html/fill-form.neighbour-orfs.cgi
+++ b/public_html/fill-form.neighbour-orfs.cgi
@@ -12,6 +12,7 @@ require "cgi-lib.pl";
 
 
 require "RSA.lib.pl";
+require "RSA2.cgi.lib";
 $form_file = "$HTML/neighbour-orfs.html";
 
 MAIN:
@@ -19,7 +20,15 @@ MAIN:
     ### Read the content of the form 
     &ReadParse(*input);
 
-    $query = `cat $input{'query_file'}`;
+    my $query = "";
+    my $query_file = &rsat_resolve_job_id_file($input{'job_id'});
+    if ($query_file && open(my $qfh, "<", $query_file)) {
+        local $/ = undef;
+        $query = <$qfh>;
+        close $qfh;
+    } elsif (defined $input{'query'} && $input{'query'} ne '') {
+        $query = $input{'query'};
+    }
 
     ### Print the header
     print &PrintHeader;

--- a/public_html/raul_form.cgi
+++ b/public_html/raul_form.cgi
@@ -36,9 +36,13 @@ foreach $key (keys %default) {
     }
 }
 
-if (-e $query->param('feature_file')) {
-    $file = $query->param('feature_file');
-    $default{data} = `cat $file`;
+my $prefill_file = &rsat_resolve_job_id_file($query->param('job_id'));
+if ($prefill_file) {
+    if (open my $fh, "<", $prefill_file) {
+        local $/ = undef;
+        $default{data} = <$fh>;
+        close $fh;
+    }
 } else {
     $default{data} = $query->param('data');
 }


### PR DESCRIPTION
# 🛡️ PR de Seguridad – RSAT

## 🚦 Estado del PR

- [x] Borrador / análisis inicial
- [x] Implementación en curso
- [x] Implementación terminada
- [ ] Probado en VM
- [ ] Pruebas funcionales completadas
- [ ] Pruebas de seguridad completadas
- [ ] Validado por Jacques
- [ ] Listo para merge


## 📌 Resumen
Elimina lectura de ficheros via `cat $ruta` cuando la ruta venia del cliente (feature_file, XYgraph_file, query_file). Prefill con job_id resuelto por rsat_resolve_job_id_file y lectura Perl con open.

---

## 🔍 Problema identificado

- Tipo de vulnerabilidad:
  - [x] Command Injection
  - [x] Path Traversal
  - [x] Arbitrary File Read
  - [ ] Input Validation
  - [ ] Otro: ___________

- Descripción: Formularios de feature-map, raul, XYgraph y neighbour-orfs leían contenido de rutas controladas por el usuario.

---

## ⚠️ Riesgo

- [ ] Ejecución remota de comandos (RCE)
- [x] Lectura de archivos del sistema
- [ ] Exposición de datos
- [ ] Otro: ___________

---

## 🛠️ Cambios realizados

- Parámetro afectado: job_id (nuevo id); queda obsoleto feature_file/XYgraph_file/query_file como ruta 
- Estrategia aplicada: rsat_resolve_job_id_file + lectura sin shell; query inline en neighbour-orfs si aplica
- Archivos modificados:

```text
public_html/feature-map_form.cgi
public_html/feature-map_form2.cgi
public_html/raul_form.cgi
public_html/XYgraph_form.cgi
public_html/fill-form.neighbour-orfs.cgi
```


## 🔐 Nueva estrategia implementada

El cliente envía job_id (nombre de fichero bajo tmp del servidor). El servidor valida y lee el archivo; nunca ejecuta cat con input de usuario.

Compatibilidad: enlaces antiguos con feature_file=/ruta/... dejan de funcionar; actualizar piping a job_id=.



## 🧪 Pruebas de seguridad

### Caso: job_id traversal

Input:

```text
job_id=../../../etc/passwd
```

Resultado esperado:

```text
sin contenido de passwd; formulario vacio o error.
```

Resultado obtenido:

 ```text
(pendiente VM)
 ```


### Caso: feature_file legacy con ruta

Input:

 ```text
feature_file=/etc/passwd
 ```

Resultado esperado:

 ```text
Rechazo en CheckWebInput (PR1) si aún se envía el param
 ```

Resultado obtenido:

 ```text
(pendiente VM)
 ```

---

## ✅ Pruebas funcionales

- [ ] feature-map_form: prefill con job_id de resultado real en tmp
- [ ] feature-map_form2/raul_form: mismo
- [ ] XYgraph_form: prefill datos demo/real
- [ ] fill-form.neighbour-orfs: job_id o query texto

Descripción:

 ```text
1) Ejecutar herramienta que deje fichero en get_pub_temp().
2) Abrir formulario con ?job_id=<nombre_fichero>.
3) Verificar textarea rellena.
 ```

---

## 📸 Evidencia

(Pendiente VM)

---

## ⚙️ Impacto

- [ ] No rompe compatibilidad - si cambia contrato de piping (ruta -> job_id)
- [ ] Cambios mínimos
- [x] Requiere documentación en securing-policy / ayuda interna

---

## 📚 Documentación relacionada

Issue:

https://github.com/rsa-tools/securing-policy/issues/4#issue-4493747704
https://github.com/rsa-tools/securing-policy/issues/6#issue-4493761720
https://github.com/rsa-tools/securing-policy/issues/5#issue-4493754153

---

## 👥 Revisión

- Implementado por: Carlos
- Revisado por: Bruno
- Validación final: Jacques

---

## 🚀 Checklist final

- [x] Vulnerabilidad corregida en formularios listados
- [x] Sin cat con parámtero de usuario
- [ ] Probado en VM
- [ ] Documentación actualizada
- [ ] Listo para validación

---

## 🧠 Notas adicionales

```text
Limitación Fase 1: job_id resuelve fichero en raíz de get_pub_temp(); subdirs YYYY/MM/DD pueden requerir Fase 3.
```
