### PR TITLE
fix(security): [C2/H1/H2] CGI parameter hardening

### DIFF
--- a/public_html/convert-background-model.cgi
+++ b/public_html/convert-background-model.cgi
@@ -54,6 +54,8 @@ if ($bg_method eq "rsat") {
   #my $bg_taxo = $query->param('bg_taxo');
   #if ($bg_taxo eq "organism"){
   my $organism_name = $query->param("organism_bg");
+  $organism_name = &CheckOrganismAvail($organism_name);
+  &FatalError("Invalid organism for background model") if (!defined $organism_name || $organism_name eq "");
   $parameters .= " -org ".$organism_name;
   #}
 
@@ -106,7 +108,10 @@ if ($bg_method eq "rsat") {
     }
     close BGFILE;
     $parameters .= " -i $bgfile";
-    $parameters .= " -from ".$query->param('bg_format');
+    my $bg_format = lc($query->param('bg_format') || '');
+    my %allowed_bg_format = map { $_ => 1 } qw(tab oligo-analysis markov transitions counts freq frequency);
+    &FatalError("Invalid background format") unless $allowed_bg_format{$bg_format};
+    $parameters .= " -from ".$bg_format;
   } else {
     &FatalError ("If you want to upload a background model file, you should specify the location of this file on your hard drive with the Browse button");
   }

--- a/public_html/getMatrix.cgi
+++ b/public_html/getMatrix.cgi
@@ -17,6 +17,7 @@ require "RSA2.cgi.lib";
 $ENV{RSA_OUTPUT_CONTEXT} = "cgi";
 
 $query = new CGI;
+&CheckWebInput($query);
 
 my $mode = $query->param("mode");
 my $output = $query->param("output");
@@ -43,8 +44,13 @@ if($mode ne "retrieve" && $output ne "email"){
 
 ##### execute la commande retrieve-matrix
 $file_name = $ENV{RSAT} . "/public_html/motif_databases/" . $file;
-$id = $query->param("db_id");
-$command = "$SCRIPTS/retrieve-matrix -i $file_name -id $id 2> /dev/null";
+my $id = $query->param("db_id") || "";
+if ($id !~ /^[A-Za-z0-9_.-]{1,128}$/) {
+    die "Invalid db_id";
+}
+my $quoted_file_name = &rsat_shell_quote($file_name);
+my $quoted_id = &rsat_shell_quote($id);
+$command = "$SCRIPTS/retrieve-matrix -i $quoted_file_name -id $quoted_id 2> /dev/null";
 open RESULT, "$command |";
 
 ######## return json array of all information

--- a/public_html/getMatrixIds.cgi
+++ b/public_html/getMatrixIds.cgi
@@ -17,6 +17,8 @@ require "RSA2.cgi.lib";
 $ENV{RSA_OUTPUT_CONTEXT} = "cgi";
 
 $query = new CGI;
+&CheckWebInput($query);
+my $mode = $query->param("mode") || "";
 
 if($mode eq 'retrieveweb'){
     print "Content-type:application/json; charset=iso-8859-1\n\n";
@@ -26,7 +28,6 @@ if($mode eq 'retrieveweb'){
 
 my @dbs_choice = split(",", $query->param("dbs_choice"));
 my $db_choice = $query->param("db_choice") || "";
-my $mode = $query->param("mode") || "";
 
 my $motif_folder = "/public_html/motif_databases/";
 
@@ -100,8 +101,13 @@ if($mode eq "db"){
     }
     ##### execute la commande retrieve-matrix
     $file_name = $ENV{RSAT} . $motif_folder . $file;
-    $id = $query->param("db_id");
-    $command = "$SCRIPTS/retrieve-matrix -i $file_name -id $id 2> /dev/null";
+    my $id = $query->param("db_id") || "";
+    if ($id !~ /^[A-Za-z0-9_.-]{1,128}$/) {
+        die "Invalid db_id";
+    }
+    my $quoted_file_name = &rsat_shell_quote($file_name);
+    my $quoted_id = &rsat_shell_quote($id);
+    $command = "$SCRIPTS/retrieve-matrix -i $quoted_file_name -id $quoted_id 2> /dev/null";
     open RESULT, "$command |";
     
     ######## return json array of all information

--- a/public_html/retrieve-seq.cgi
+++ b/public_html/retrieve-seq.cgi
@@ -82,12 +82,20 @@ if ($query->param('single_multi_org') eq 'multi') {
 ### feature type
 if ($query->param('feattype')) {
     my ($feattype) = split " ", $query->param('feattype'); ### take the first word
+    my %allowed_feattype = map { $_ => 1 } qw(CDS gene mRNA tRNA rRNA ncRNA operon transcript exon intron);
+    unless ($allowed_feattype{$feattype}) {
+        &FatalError("Invalid feature type");
+    }
     $parameters .= " -feattype ".$feattype;
 }
 
 ### sequence type
 if ($query->param('sequence_type')) {
     ($seq_type) = split " ", $query->param('sequence_type'); ### take the first word
+    my %allowed_sequence_type = map { $_ => 1 } qw(dna protein);
+    unless ($allowed_sequence_type{$seq_type}) {
+        &FatalError("Invalid sequence type");
+    }
     $parameters .= " -type ".$seq_type;
 }
 


### PR DESCRIPTION
# 🛡️ PR de Seguridad – RSAT

## 🚦 Estado del PR

- [x] Borrador / análisis inicial
- [x] Implementación en curso
- [x] Implementación terminada
- [ ] Probado en VM
- [ ] Pruebas funcionales completadas
- [ ] Pruebas de seguridad completadas
- [ ] Validado por Jacques
- [ ] Listo para merge


## 📌 Resumen

Endurecimiento puntual: db_id en getMatrix/getMatrixIds, allow-lists en retrieve-seq, validación de organismo y formato de fondo en convert-background-model.

---

## 🔍 Problema identificado

- Tipo de vulnerabilidad:
  - [x] Command Injection
  - [ ] Path Traversal
  - [ ] Arbitrary File Read
  - [x] Input Validation
  - [ ] Otro: ___________

- Descripción:

Parámetros interpolados en comandos shell sin lista cerrada o sin Check0rganismAvil.

---

## ⚠️ Riesgo

- [x] Ejecución remota de comandos (RCE)
- [ ] Lectura de archivos del sistema
- [ ] Exposición de datos
- [x] Otro: Comportamiento inseguro / comandos mal formados (retrieve-seq, convert-background)

---

## 🛠️ Cambios realizados

| Hallazgo | Archivo | Cambio |
|----------|---------|--------|
| C2 | getMatrix.cgi, getMatrixIds.cgi | CheckWebInput, regex db_id, rsat_shell_quote, fix orden $mode |
| H1 | retrieve-seq.cgi | allow-list feattype, sequence_type |
| H2 | convert-background-model.cgi | CheckOrganismAvail, allow-list bg_format |

```text
public_html/getMatrix.cgi
public_html/getMatrixIds.cgi
public_html/retrieve-seq.cgi
public_html/convert-background-model.cgi
```


## 🔐 Nueva estrategia implementada

- db_id: solo [A - Za - z0-9_.-]{1, 128}; armugentos citados al invocar retrive-matrix (sigue pipe shell - Fase 2).
- feattype / sequence_type: conjuntos cerrados antes de añadir a $parameters.
- organism_bg / bg_format: organismo instalado; formatos de upload en lista fija.



## 🧪 Pruebas de seguridad

### Caso: db_id injection (getMatrix)

```text
Input: db_id=M00001;id
```

Resultado esperado:

```text
rechazo o error, sin ejecucion de id.
```

Resultado obtenido:

 ```text
(pendiente VM)
 ```


### Caso: feattype injection (retrieve-seq)

Input:

 ```text
feattype=CDS;id
 ```

Resultado esperado:

 ```text
FatalError "Invalid feature type"
 ```

Resultado obtenido:

 ```text
(pendiente VM)
 ```

---

## ✅ Pruebas funcionales

- [ ] getMatrix / getMatrixIds: modo retrieve con db_id válido -> JSON/matrix OK
- [ ] retrieve-seq: CDS + dna, resultado fasta esperado
- [ ] convert-background-model: organismo RSAT + upload tab

---

## 📸 Evidencia

(Pendiente VM)

---

## ⚙️ Impacto

- [x] Cambios acotados a CGI listados
- [ ] Shell en getMatrix: parcial (validacion + quoting)

Descripción:

```text
(explicar impacto)
```

---

## 📚 Documentación relacionada

Issue:

https://github.com/rsa-tools/securing-policy/issues/3#issue-4493733738
https://github.com/rsa-tools/securing-policy/issues/7#issue-4493766081
https://github.com/rsa-tools/securing-policy/issues/8#issue-4493771162

---

## 👥 Revisión

- Implementado por: Carlos
- Revisado por: Bruno
- Validación final: Jacques

---

## 🚀 Checklist final

- [x] Vulnerabilidad corregida
- [x] Inputs validados en script modificados
- [ ] Sin uso de shell en getMatrix - parcial (open pipe, quoting + validacion)
- [ ] Pruebas de seguridad ejecutadas
- [ ] Pruebas funcionales ejecutadas
- [ ] Probado en VM
- [ ] Documentación actualizada
- [ ] Listo para validación


