### PR TITLE
fix(security): [C4] Flask - remove shell=True

### DIFF
--- a/public_html/flask/lib/utils.py
+++ b/public_html/flask/lib/utils.py
@@ -1,5 +1,6 @@
 import os,sys,re
 import json
+import shlex
 #from subprocess import check_output, Popen, PIPE
 import subprocess
 from tempfile import mkstemp, mkdtemp, NamedTemporaryFile
@@ -100,8 +101,14 @@ def get_backgroundfile(org, oligo_len, background="upstream-noorf"):
 	
 	:return: name of background file
 	"""
-	command = "perl -e 'use lib \"" + perl_scripts + "/lib/\"; use RSAT::OrganismManager; $x=&RSAT::OrganismManager::ExpectedFreqFile(\"" + org + "\","+ str(oligo_len) +",\""+ background+"\", str=>\"-1str\", noov=>\"ovlp\"); print $x;'"
-	p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	if not re.match(r'^[A-Za-z0-9_.:-]+$', org):
+		raise ValueError('Invalid org parameter')
+	if not re.match(r'^[A-Za-z0-9_-]+$', background):
+		raise ValueError('Invalid background parameter')
+	perl_code = 'use lib "{}"; use RSAT::OrganismManager; $x=&RSAT::OrganismManager::ExpectedFreqFile("{}",{},"{}", str=>"-1str", noov=>"ovlp"); print $x;'.format(
+		perl_scripts + '/lib/', org, int(oligo_len), background
+	)
+	p = subprocess.Popen(['perl', '-e', perl_code], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 	file = p.stdout.readline()
 	return file
 
@@ -354,8 +361,8 @@ def run_command_background(command, method_name, out_dir='', summary_page=''):
     response['result_path'] = hide_RSAT_path(result_dir)
     response['result_url'] = make_url(result_file)
     
-    command = 'nice -n 19 ' + command + ' &'
-    os.system(command)
+    argv = ['nice', '-n', '19'] + shlex.split(command)
+    subprocess.Popen(argv, close_fds=True)
     return response
     
 def run_command(command, output_choice, method_name, out_format, out_dir=''):          
@@ -371,7 +378,8 @@ def run_command(command, output_choice, method_name, out_format, out_dir=''):
     :return: a JSON object containing the full command, the result or the warning/error of the command and the link/path to it if the content-type is json. Or the result of the command if the content-type is text.
     
     """
-    p = subprocess.Popen(command, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    argv = shlex.split(command)
+    p = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
     (child_stdin, child_stdout, child_stderr) = (p.stdin, p.stdout, p.stderr)
     result = ''
     for line in iter(child_stdout.readline, ''):

--- a/public_html/flask/rest_server_rsaticus.py
+++ b/public_html/flask/rest_server_rsaticus.py
@@ -7,6 +7,7 @@ import os
 from time import localtime
 import datetime
 import pwd
+import shlex
 
 app = Flask(__name__, static_url_path = "")
 
@@ -214,7 +215,7 @@ def oligo_analysis_pipeline():
     logfile = tmp_path + '/snakemake.log'
 
     command = perl_scripts + '/snakemake --snakefile ' + perl_scripts + '/oligo_analysis_pipeline --configfile ' + tmp_path + '/config.json --core 5 --directory ' + tmp_path + ' oligo_all 2> ' + logfile
-    p = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
+    p = Popen(shlex.split(command), stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
 
     (child_stdin, child_stdout, child_stderr) = (p.stdin, p.stdout, p.stderr)
     result = ''
@@ -250,7 +251,7 @@ def oligo_analysis_pipeline():
 
 def run_command(command, output_choice, method_name, out_format):
     ### execute command
-    p = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
+    p = Popen(shlex.split(command), stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
     (child_stdin, child_stdout, child_stderr) = (p.stdin, p.stdout, p.stderr)
     result = ''
     for line in iter(child_stdout.readline, ''):


### PR DESCRIPTION
# 🛡️ PR de Seguridad – RSAT

## 🚦 Estado del PR

- [x] Borrador / análisis inicial
- [x] Implementación en curso
- [x] Implementación terminada
- [ ] Probado en VM
- [ ] Pruebas funcionales completadas
- [ ] Pruebas de seguridad completadas
- [ ] Validado por Jacques
- [ ] Listo para merge


## 📌 Resumen

Elimina shell=True y os.system en los modulos Flask revisados; get_backgroundfile invoca perl -e con lista de argumentos y valida org y background por regex.

---

## 🔍 Problema identificado

- Tipo de vulnerabilidad:
  - [x] Command Injection
  - [ ] Path Traversal
  - [ ] Arbitrary File Read
  - [x] Input Validation
  - [ ] Otro: ___________

- Descripción:

subprocess.Popen(..., shell=True) y one-liners Perl con datos de petición.

---

## ⚠️ Riesgo

- [x] Ejecución remota de comandos (RCE)
- [ ] Lectura de archivos del sistema
- [ ] Exposición de datos
- [ ] Otro: ___________

---

## 🛠️ Cambios realizados

- Parámetro afectado: org, backgorund (get_backgroundfile); cadenas de comando en run_command / background jobs
- Estrategia aplicada: Popen(['perl','-e',...]); shlex.split + Popen(argv); nice como lista
- Archivos modificados:

```text
public_html/flask/lib/utils.pyy
public_html/flask/rest_server_rsaticus.py
```


## 🔐 Nueva estrategia implementada

El intérprete no recibe una cadena única interpretada por /bin/sh. Parámetros que alimentan Perl deben cumplir regex antes de construir el código embebido.

Residual: endpoints que sigan armando command como string deben validarse en Fase 4 del plan.



## 🧪 Pruebas de seguridad

### Caso: org inválido en get_backgroundfile

Input:

```text
org=../../etc
```

Resultado esperado:

```text
ValueError o error controlado, sin ejecución shell.
```

Resultado obtenido:

 ```text
(Pendiente VM)
 ```


### Caso: Búsqueda de shell=True

Resultado esperado:

 ```text
ningún shell=True en los dos archivos del diff.
 ```

Resultado obtenido:

 ```text
grep -R shell=True public_html/flask/lib/utils.py public_html/flask/rest_server_rsaticus.py → vacío (verificar en VM)
 ```

---

## ✅ Pruebas funcionales

- [ ] Servicio REST que use run_command responde como antes con parámetros válidos.
- [ ] get_backgroundfile devuelve ruta de fondo para organismo/oligo_len válidos.

## 📸 Evidencia

(Pendiente VM)


---

## 📚 Documentación relacionada

Issue:

https://github.com/rsa-tools/securing-policy/issues/9#issue-4493776346

---

## 👥 Revisión

- Implementado por: Carlos
- Revisado por: Bruno
- Validación final: Jacques

---

## 🚀 Checklist final

- [ ] Vulnerabilidad corregida
- [ ] Inputs validados
- [ ] Sin uso de shell
- [ ] Pruebas de seguridad ejecutadas
- [ ] Pruebas funcionales ejecutadas
- [ ] Probado en VM
- [ ] Documentación actualizada
- [ ] Listo para validación
